### PR TITLE
Profile claims only issue not issued access token

### DIFF
--- a/azidp4j-spring-security-sample/README.md
+++ b/azidp4j-spring-security-sample/README.md
@@ -173,7 +173,7 @@ aws ecr-public get-login-password --region us-east-1 | docker login --username A
 ```
 
 ```
-VERSION=v26
+VERSION=v32
 docker tag azidp4j/spring-security-sample:latest public.ecr.aws/f8x3d3l2/azidp4j-spring-security-sample:${VERSION}
 docker push public.ecr.aws/f8x3d3l2/azidp4j-spring-security-sample:${VERSION}
 ```

--- a/azidp4j-spring-security-sample/src/main/java/org/azidp4j/springsecuritysample/handler/DynamicClientRegistrationEndpointHandler.java
+++ b/azidp4j-spring-security-sample/src/main/java/org/azidp4j/springsecuritysample/handler/DynamicClientRegistrationEndpointHandler.java
@@ -38,7 +38,7 @@ public class DynamicClientRegistrationEndpointHandler {
         if (!requestBody.containsKey("scope")) {
             // OIDC Conformance test only supports OIDC registration so insert openid scope
             requestWithScope = new HashMap<>(requestBody);
-            requestWithScope.put("scope", "openid");
+            requestWithScope.put("scope", "openid profile email address phone");
         }
 
         // Client Registration Request

--- a/azidp4j/src/main/java/org/azidp4j/authorize/Authorize.java
+++ b/azidp4j/src/main/java/org/azidp4j/authorize/Authorize.java
@@ -518,6 +518,16 @@ public class Authorize {
 
         String idToken = null;
         if (responseType.contains(ResponseType.id_token)) {
+            var accessTokenWillIssued = true;
+            if (accessToken == null & authorizationCode == null) {
+                // https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
+                // The Claims requested by the profile, email, address, and phone scope values are
+                // returned from the UserInfo Endpoint, as described in Section 5.3.2, when a
+                // response_type value is used that results in an Access Token being issued.
+                // However, when no Access Token is issued (which is the case for the response_type
+                // value id_token), the resulting Claims are returned in the ID Token.
+                accessTokenWillIssued = false;
+            }
             idToken =
                     idTokenIssuer
                             .issue(
@@ -528,7 +538,8 @@ public class Authorize {
                                     accessToken,
                                     authorizationCode,
                                     client.idTokenSignedResponseAlg,
-                                    scope)
+                                    scope,
+                                    accessTokenWillIssued)
                             .serialize();
         }
 

--- a/azidp4j/src/main/java/org/azidp4j/token/IssueToken.java
+++ b/azidp4j/src/main/java/org/azidp4j/token/IssueToken.java
@@ -180,7 +180,8 @@ public class IssueToken {
                                     at.token,
                                     null,
                                     client.idTokenSignedResponseAlg,
-                                    authorizationCode.scope);
+                                    authorizationCode.scope,
+                                    false);
                     if (authorizationCode.state == null) {
                         return new TokenResponse(
                                 200,

--- a/azidp4j/src/main/java/org/azidp4j/token/idtoken/IDTokenIssuer.java
+++ b/azidp4j/src/main/java/org/azidp4j/token/idtoken/IDTokenIssuer.java
@@ -48,7 +48,8 @@ public class IDTokenIssuer {
             String accessToken,
             String authorizationCode,
             SigningAlgorithm alg,
-            String scope) {
+            String scope,
+            boolean accessTokenWillIssued) {
         var jti = UUID.randomUUID().toString();
         var atHash = accessToken != null ? calculateXHash(accessToken) : null;
         var cHash = authorizationCode != null ? calculateXHash(authorizationCode) : null;
@@ -76,7 +77,7 @@ public class IDTokenIssuer {
                         atHash,
                         "c_hash",
                         cHash);
-        if (idTokenClaimsAssembler != null) {
+        if (idTokenClaimsAssembler != null && !accessTokenWillIssued) {
             var profiles =
                     idTokenClaimsAssembler.assemble(
                             sub,


### PR DESCRIPTION
https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
> The Claims requested by the profile, email, address, and phone scope values are returned from the UserInfo Endpoint, as described in [Section 5.3.2](https://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse), when a response_type value is used that results in an Access Token being issued. However, when no Access Token is issued (which is the case for the response_type value id_token), the resulting Claims are returned in the ID Token.